### PR TITLE
feat: add `/api/option` APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,7 @@ dist
 
 # vercel
 .vercel
+
+# local environment variables
+.env
+.env.*

--- a/graphql/query.js
+++ b/graphql/query.js
@@ -36,3 +36,16 @@ export const getFeedback = gql`
     }
   }
 `
+
+export const getFieldOptions = gql`
+  query ($field: ID!) {
+    field(where: { id: $field }) {
+      id
+      options {
+        id
+        name
+        value
+      }
+    }
+  }
+`

--- a/pages/api/like.js
+++ b/pages/api/like.js
@@ -6,7 +6,7 @@ import { addLikeOrDislike } from '../../utils/api/addDataToStorage'
 import { corsOrigins } from '../../utils/api/config'
 
 const cors = CORS({
-  methods: ['HEAD', 'PUT'],
+  methods: ['HEAD', 'PUT', 'GET'],
   origin: corsOrigins,
 })
 

--- a/pages/api/option.js
+++ b/pages/api/option.js
@@ -1,0 +1,42 @@
+import CORS from 'cors'
+import globalAPICall from '../../utils/api/globalAPICall'
+import { runMiddleware } from '../../utils/api/share'
+import { getOptionSummary } from '../../utils/api/getDataFromStorage'
+import { addOption } from '../../utils/api/addDataToStorage'
+import { corsOrigins } from '../../utils/api/config'
+
+const cors = CORS({
+  methods: ['HEAD', 'PUT', 'GET'],
+  origin: corsOrigins,
+})
+
+// default handler
+async function handler(req, res) {
+  await runMiddleware(req, res, cors)
+
+  async function PUT() {
+    // add like/dislike to storage
+    const result = await addOption(req)
+
+    if (result === true) {
+      res.status(200).json({})
+    } else {
+      res.status(400).json({ message: result })
+    }
+  }
+
+  // get like and dislike amount
+  async function GET() {
+    const result = await getOptionSummary(req)
+
+    if (typeof result === 'string') {
+      res.status(400).json({ message: result })
+    } else {
+      res.status(200).json(result)
+    }
+  }
+
+  await globalAPICall(req, res, { PUT, GET })
+}
+
+export default handler

--- a/utils/api/addDataToStorage.js
+++ b/utils/api/addDataToStorage.js
@@ -1,6 +1,10 @@
 import publishMessage from './publishMessage'
 import { addIpToData } from './share'
-import { feedbackFormSchema, likeFormSchema } from './validationSchema'
+import {
+  feedbackFormSchema,
+  likeFormSchema,
+  optionFormSchema,
+} from './validationSchema'
 
 export async function addFeedback(request) {
   const jsonData = await addIpToData(request, request.body)
@@ -10,4 +14,9 @@ export async function addFeedback(request) {
 export async function addLikeOrDislike(request) {
   const jsonData = await addIpToData(request, request.body)
   return await publishMessage(likeFormSchema, jsonData)
+}
+
+export async function addOption(request) {
+  const jsonData = await addIpToData(request, request.body)
+  return await publishMessage(optionFormSchema, jsonData)
 }

--- a/utils/api/config.js
+++ b/utils/api/config.js
@@ -20,3 +20,6 @@ export const recaptchaScoreBoundary =
 export const corsOrigins = env.CORS_ORIGINS
   ? env.CORS_ORIGINS.split(delimiter)
   : ['http://localhost']
+
+// for option form
+export const optionDelimiter = '$$'

--- a/utils/api/getDataFromStorage.js
+++ b/utils/api/getDataFromStorage.js
@@ -47,6 +47,20 @@ export async function getLikeAndDislikeAmount(req) {
 
     return amount
   } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'ALERT',
+        message: 'Received error while getLikeAndDislikeAmount',
+        debugPayload: {
+          error: err.message,
+          stack: err.stack,
+        },
+      })
+    )
+
+    return err.message
+  }
+}
     return err.message
   }
 }
@@ -83,6 +97,17 @@ export async function getFeedback(req) {
 
     return result
   } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'ALERT',
+        message: 'Received error while getFeedback',
+        debugPayload: {
+          error: err.message,
+          stack: err.stack,
+        },
+      })
+    )
+
     return err.message
   }
 }

--- a/utils/api/globalAPICall.js
+++ b/utils/api/globalAPICall.js
@@ -17,6 +17,17 @@ export default async function globalAPICall(req, res, actions) {
     // run the action matching the request.method
     await actions[method]()
   } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'ALERT',
+        message: 'Received unexpected error',
+        debugPayload: {
+          error: err.message,
+          stack: err.stack,
+        },
+      })
+    )
+
     if (err instanceof CustomError) {
       res.status(err.code).json({ message: err.message })
     } else {

--- a/utils/api/publishMessage.js
+++ b/utils/api/publishMessage.js
@@ -10,14 +10,35 @@ export default async function publishMessage(formSchema, jsonData) {
       stripUnknown: true,
     })
 
-    const messageId = await pubSubClient
+    await pubSubClient
       .topic(topicNameOrId)
       .publishMessage({ json: validateData })
 
-    console.log(`Message ${messageId} published.`)
+    console.log(
+      JSON.stringify({
+        severity: 'DEBUG',
+        message: 'Message published',
+        debugPayload: {
+          jsonData,
+          validateData,
+        },
+      })
+    )
+
     return true
   } catch (error) {
-    console.error(`Received error while publishing: ${error.message}`)
+    console.log(
+      JSON.stringify({
+        severity: 'ALERT',
+        message: 'Received error while publishing message',
+        debugPayload: {
+          jsonData,
+          error: error.message,
+          stack: error.stack,
+        },
+      })
+    )
+
     return error.message
   }
 }

--- a/utils/api/validationSchema.js
+++ b/utils/api/validationSchema.js
@@ -1,5 +1,6 @@
 import { truthValue, cancelValue } from './share'
 import { object, string, date, ref } from 'yup'
+import { optionDelimiter } from './config'
 
 export const basicFormSchema = object({
   form: string().required(),
@@ -8,20 +9,22 @@ export const basicFormSchema = object({
   uri: ref('identifier'),
 })
 
-export const feedbackFormSchema = basicFormSchema.concat(
+const basicInputFormSchema = basicFormSchema.concat(
   object({
     name: string().required(),
     ip: string().required(),
     responseTime: date().required(),
+  })
+)
+
+export const feedbackFormSchema = basicInputFormSchema.concat(
+  object({
     userFeedback: string().required(), // need to transform into string so that Python subscriber could handle properly
   })
 )
 
-export const likeFormSchema = basicFormSchema.concat(
+export const likeFormSchema = basicInputFormSchema.concat(
   object({
-    name: string().required(),
-    ip: string().required(),
-    responseTime: date().required(),
     userFeedback: string()
       .transform((value) => {
         // need to transform into string expression so that Python subscriber could handle properly
@@ -34,6 +37,21 @@ export const likeFormSchema = basicFormSchema.concat(
         }
       })
       .nullable()
+      .defined(),
+  })
+)
+
+// will replace likeFormSchema
+export const optionFormSchema = basicInputFormSchema.concat(
+  object({
+    userFeedback: string()
+      .transform((value) => {
+        if (Array.isArray(value)) {
+          return value.join(optionDelimiter)
+        } else {
+          return ''
+        }
+      })
       .defined(),
   })
 )


### PR DESCRIPTION
## Notable Changes
* 增加 PUT `/api/option`，作為使用者提交結果（單選、多選）使用
* 增加 GET `/api/option`，作為使用者取得選項總結資訊使用
* 調整 log 格式

## Reminder
* `/api/option` 未來會取代 `/api/like` 的功能，作為更適合單選、多選情況下使用，在 CMS 創建表單時，field 需設定關聯的 fieldOption，這樣才能夠知道實際上該 field 有多少選項